### PR TITLE
modify go.mod package to match the github repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
-module go-test-processor
+module github.com/getvictor/goteststats
+
+go 1.23.0


### PR DESCRIPTION
This should allow `go install` to work.